### PR TITLE
Fetch the data per page. Consecutive calls will fetch the next page

### DIFF
--- a/src/LdapTools/Operation/Handler/PagedQueryOperationHandler.php
+++ b/src/LdapTools/Operation/Handler/PagedQueryOperationHandler.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace LdapTools\Operation\Handler;
+
+use LdapTools\Connection\LdapConnection;
+use LdapTools\Connection\PageControl;
+use LdapTools\Exception\LdapConnectionException;
+use LdapTools\Operation\LdapOperationInterface;
+use LdapTools\Operation\QueryOperation;
+
+class PagedQueryOperationHandler implements OperationHandlerInterface  {
+    /**
+     * Internal paging control data
+     */
+    protected $pagingControlList = [];
+
+    use OperationHandlerTrait {
+        setOperationDefaults as parentSetDefaults;
+    }
+
+    public function __construct() {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(LdapOperationInterface $operation)
+    {
+
+        if ($this->removePagingOperationIfFinished($operation)) {
+            return [];
+        }
+
+        $allEntries = [];
+
+        /** @var QueryOperation $operation */
+        $this->paging($operation)['pageControl']->setIsEnabled($this->shouldUsePaging($operation));
+        if (!$this->paging($operation)['pageControl']->isActive()) {
+            $this->paging($operation)['pageControl']->start($operation->getPageSize(), $operation->getSizeLimit());
+        }
+        $this->paging($operation)['pageControl']->next();
+
+        $result = @call_user_func(
+            $operation->getLdapFunction(),
+            $this->paging($operation)['connection']->getResource(),
+            ...$operation->getArguments()
+        );
+        $allEntries = $this->processSearchResult($this->paging($operation)['connection'], $result, $allEntries);
+
+        $this->paging($operation)['pageControl']->update($result);
+
+        if (!$this->paging($operation)['pageControl']->isActive()) {
+            $this->paging($operation)['pageControl']->end();
+            $this->markPagingOperationFinished($operation);
+        }
+        @ldap_free_result($result);
+
+        return $allEntries;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(LdapOperationInterface $operation)
+    {
+        return $operation instanceof QueryOperation;
+    }
+
+    /**
+     * Gets the base DN for a search based off of the config and then the RootDSE.
+     *
+     * @return string
+     * @throws LdapConnectionException
+     */
+    protected function getBaseDn()
+    {
+        if (!empty($this->connection->getConfig()->getBaseDn())) {
+            $baseDn = $this->connection->getConfig()->getBaseDn();
+        } elseif ($this->connection->getRootDse()->has('defaultNamingContext')) {
+            $baseDn = $this->connection->getRootDse()->get('defaultNamingContext');
+        } elseif ($this->connection->getRootDse()->has('namingContexts')) {
+            $baseDn =  $this->connection->getRootDse()->get('namingContexts')[0];
+        } else {
+            throw new LdapConnectionException('The base DN is not defined and could not be found in the RootDSE.');
+        }
+
+        return $baseDn;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOperationDefaults(LdapOperationInterface $operation)
+    {
+        /** @var QueryOperation $operation */
+        if (is_null($operation->getPageSize())) {
+            $operation->setPageSize($this->connection->getConfig()->getPageSize());
+        }
+        if (is_null($operation->getBaseDn())) {
+            $operation->setBaseDn($this->getBaseDn());
+        }
+        if (is_null($operation->getUsePaging())) {
+            $operation->setUsePaging($this->connection->getConfig()->getUsePaging());
+        }
+        $this->parentSetDefaults($operation);
+    }
+
+    /**
+     * Process a LDAP search result and merge it with the existing entries if possible.
+     *
+     * @param LdapConnection $connection
+     * @param resource $result
+     * @param array $allEntries
+     * @return array
+     * @throws LdapConnectionException
+     */
+    protected function processSearchResult(LdapConnection $connection, $result, array $allEntries)
+    {
+        if (!$result) {
+            throw new LdapConnectionException(sprintf(
+                'LDAP search failed. Diagnostic message: "%s"',
+                $this->connection->getDiagnosticMessage()
+            ));
+        }
+
+        $entries = @ldap_get_entries($connection->getResource(), $result);
+        if (!$entries) {
+            return $allEntries;
+        }
+        $allEntries['count'] = isset($allEntries['count']) ? $allEntries['count'] + $entries['count'] : $entries['count'];
+        unset($entries['count']);
+
+        return array_merge($allEntries, $entries);
+    }
+
+    /**
+     * Get a key for the operation. This key will be used to store pagination data for the operation
+     * such as the PageControl and LdapConnection object.
+     *
+     * @param LdapOperationInterface $operation the operation to generate the key for
+     * @return string the generated key
+     */
+    protected function getPagingKey(LdapOperationInterface $operation)
+    {
+        $keyArray = [$operation->getServer(), $operation->getLdapFunction()] + $operation->getArguments();
+        return serialize($keyArray);
+    }
+
+    /**
+     * Returns paging data for the operation. This data is reused if the operation is the same.
+     *
+     * @param LdapOperationInterface $operation the operation that needs pagination
+     * @return array containing the PageControl and LdapConnection for the operation such as
+     * ['pageControl' => PageControl, 'connection' => LdapConnection]
+     */
+    protected function paging(LdapOperationInterface $operation)
+    {
+        $pagingKey = $this->getPagingKey($operation);
+        if (!isset($this->pagingControlList[$pagingKey])) {
+            $clonedConnection = clone $this->connection;
+            $clonedConnection->close();
+            $clonedConnection->connect();
+            $this->pagingControlList[$pagingKey] = [
+                'pageControl' => new PageControl($clonedConnection),
+                'connection' => $clonedConnection
+                ];
+        }
+        return $this->pagingControlList[$pagingKey];
+    }
+
+    /**
+     * Based on the query operation, determine whether paging should be used.
+     *
+     * @param QueryOperation $operation
+     * @return bool
+     */
+    protected function shouldUsePaging(QueryOperation $operation)
+    {
+        return ($operation->getUsePaging() && $operation->getScope() != QueryOperation::SCOPE['BASE']);
+    }
+
+    /**
+     * Mark the pagination as finished for the operation. This will set the 'pageControl' as false
+     * but keep the connection in order to close it later.
+     *
+     * @param LdapOperationInterface the operation that will be marked as finished
+     */
+    protected function markPagingOperationFinished(LdapOperationInterface $operation)
+    {
+        $pagingKey = $this->getPagingKey($operation);
+        $this->pagingControlList[$pagingKey]['pageControl'] = false;
+    }
+
+    /**
+     * Remove the paging data if the operation has finished. This will close the connection if
+     * needed. If the operation hasn't finished, this method won't do anything
+     *
+     * @param LdapOperationInterface $operation the finished operation marked with the
+     * 'markPagingOperationFinished' method. You can pass unfinished operations, but it won't have
+     * any effect
+     * @return bool true if the data has been removed, false otherwise (if the operation hasn't
+     * finished, it will return false since the data is still there)
+     */
+    protected function removePagingOperationIfFinished(LdapOperationInterface $operation)
+    {
+        $pagingKey = $this->getPagingKey($operation);
+        if (isset($this->pagingControlList[$pagingKey]) && $this->pagingControlList[$pagingKey]['pageControl'] === false) {
+            $this->pagingControlList[$pagingKey]['connection']->close();
+            unset($this->pagingControlList[$pagingKey]);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/LdapTools/Operation/Invoker/LdapOperationInvokerForPaging.php
+++ b/src/LdapTools/Operation/Invoker/LdapOperationInvokerForPaging.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LdapTools\Operation\Invoker;
+
+use LdapTools\Operation\Handler\AuthenticationOperationHandler;
+use LdapTools\Operation\Handler\OperationHandler;
+use LdapTools\Operation\Handler\PagedQueryOperationHandler;
+use LdapTools\Operation\LdapOperationInterface;
+
+/**
+ * The class just change the QueryOperationHandler for the PagedQueryOperationHandler. The rest
+ * of the functionality remains the same
+ */
+class LdapOperationInvokerForPaging extends LdapOperationInvoker
+{
+    public function __construct()
+    {
+        $this->addHandler(new OperationHandler());
+        $this->addHandler(new PagedQueryOperationHandler());
+        $this->addHandler(new AuthenticationOperationHandler());
+    }
+}


### PR DESCRIPTION
Use  ->setOperationInvoker(new LdapOperationInvokerForPaging()) to
activate this change. ->setUsePaging(true) is needed to get data per
page, otherwise all the data will be returned.

Example code:
```
$config = new Configuration();

// A domain configuration object. Requires a domain name, servers, username, and password. 
$domain = (new DomainConfiguration('mydomain.com'))
   ->setBaseDn('dc=domain,dc=com')
   ->setServers(['10.0.2.8'])
   ->setPort(11111)
   ->setUsername('cn=admin,dc=domain,dc=com')
   ->setPassword('password')
   ->setOperationInvoker(new LdapOperationInvokerForPaging())
   ->setUsePaging(true)
   ->setPageSize(250);

$config->addDomain($domain);
// Defaults to the first domain added. You can change this if you want.

$ldap = new LdapManager($config);

$query = $ldap->buildLdapQuery();
$ldap_query = $query->select(['dn'])
   ->where(["objectClass" => "inetOrgPerson"])
   ->setBaseDn('ou=people,dc=domain,dc=com')
   ->getLdapQuery();

while ($users = $ldap_query->getArrayResult()) {
  print_r($users);  // or do other things
}
```

Note that caching hasn't been tested but I don't think it will work properly, so I guess it should be disabled when it's used with the new operation invoker.