### PR TITLE
Range handling

### DIFF
--- a/src/LdapTools/Resolver/AttributeNameResolver.php
+++ b/src/LdapTools/Resolver/AttributeNameResolver.php
@@ -58,6 +58,10 @@ class AttributeNameResolver
             if ($this->selectedButNotPartOfEntry($attribute, $newEntry)) {
                 $newEntry[MBString::array_search_get_value($attribute, $this->selectedAttributes)] = $value;
             }
+            // include range attributes
+            if ($this->isRangeAttribute($attribute)) {
+                $newEntry[MBString::strtolower($attribute)] = $value;
+            }
         }
         // The DN attribute must be present as it is used in many critical functions.
         $newEntry = $this->addDnFromLdapIfNotPresent($newEntry, $entry);
@@ -115,6 +119,10 @@ class AttributeNameResolver
         $existsInEntry = array_key_exists($lcAttribute, MBString::array_change_key_case($entry));
 
         return ($inSelectedAttributes && !$existsInEntry);
+    }
+
+    protected function isRangeAttribute($attribute) {
+        return strpos($attribute, ';range=') !== false;
     }
 
     /**


### PR DESCRIPTION
From https://msdn.microsoft.com/en-us/library/aa367017(v=vs.85).aspx

Decided to go through the easy route and forward any attribute with a range.

Without this patch, if AD send any attribute with a range, the library will ignore it since it won't match what the user requested. This will lead to errors if the attribute has more values than the AD limit.
By forwarding these attributes the user will be able to handle it on his own, fetch the first bunch of results and ask for the next bunch.

As a short term solution this should be enough. There could be users who don't need to fetch all the values and will show whatever the server sends, and fetch more values on demand. Other users might need to fetch all values. There could be logic in the library to handle both scenarios, but this would be a long term solution.