### PR TITLE
Make sure guid is read when using ldap

### DIFF
--- a/resources/schema/openldap.yml
+++ b/resources/schema/openldap.yml
@@ -31,7 +31,7 @@ objects:
             description: description
             displayName: displayName
             dn: dn
-            emailAddress: email
+            emailAddress: mail
             employeeNumber: employeeNumber
             fax: fax
             firstName: givenName

--- a/resources/schema/openldap.yml
+++ b/resources/schema/openldap.yml
@@ -36,6 +36,7 @@ objects:
             fax: fax
             firstName: givenName
             groups: memberOf
+            guid: entryUUID
             homeDirectory: homeDirectory
             homePhone: homePhone
             initials: initials
@@ -57,6 +58,7 @@ objects:
             - 'lastName'
             - 'emailAddress'
             - 'dn'
+            - 'guid'
         multivalued_attributes:
             - 'groups'
     group:

--- a/resources/schema/openldap.yml
+++ b/resources/schema/openldap.yml
@@ -31,7 +31,7 @@ objects:
             description: description
             displayName: displayName
             dn: dn
-            emailAddress: mail
+            emailAddress: email
             employeeNumber: employeeNumber
             fax: fax
             firstName: givenName

--- a/spec/LdapTools/Schema/Parser/SchemaYamlParserSpec.php
+++ b/spec/LdapTools/Schema/Parser/SchemaYamlParserSpec.php
@@ -96,10 +96,18 @@ class SchemaYamlParserSpec extends ObjectBehavior
         );
     }
 
-    function it_should_set_default_attributes_to_select_in_LdapObjectSchema_when_parsing()
+    function it_should_set_default_attributes_to_select_in_LdapObjectSchema_when_parsing_ad()
     {
         $attributes = ['name', 'firstName', 'lastName','username', 'emailAddress', 'dn', 'guid'];
         $this->parse('ad', 'user')
+            ->getAttributesToSelect()
+            ->shouldBeEqualTo($attributes);
+    }
+
+    function it_should_set_default_attributes_to_select_in_LdapObjectSchema_when_parsing_ldap()
+    {
+        $attributes = ['firstName', 'lastName', 'emailAddress', 'dn', 'guid'];
+        $this->parse('openldap', 'user')
             ->getAttributesToSelect()
             ->shouldBeEqualTo($attributes);
     }


### PR DESCRIPTION
The OpenLDAP schema does not read the GUID when fetching a user.

This pull requests updates the schema definition and adds a test to make sure, that the guid is read.