### PR TITLE
The correct fieldname for email in ldap is mail, not email

### DIFF
--- a/resources/schema/openldap.yml
+++ b/resources/schema/openldap.yml
@@ -31,7 +31,7 @@ objects:
             description: description
             displayName: displayName
             dn: dn
-            emailAddress: email
+            emailAddress: mail
             employeeNumber: employeeNumber
             fax: fax
             firstName: givenName


### PR DESCRIPTION
From everything I could find (including my own installation), the email attribute in Open LDAP seems to be `mail`, not `email`